### PR TITLE
Add continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: CI for ai-act-sound-data-science workshop
+
+on: push
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt -r requirements-dev.txt
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,20 +17,21 @@ permissions:
 
 jobs:
   run-tests:
-    name: "Test suite on ${{ matrix.os }}"
+    name: "Test suite on ${{ matrix.os }} using Python ${{ matrix.python-version }}"
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "${{ matrix.python-version }}"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,14 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  run-tests:
+    name: "Test suite on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
 
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,14 @@
 
 name: CI for ai-act-sound-data-science workshop
 
-on: push
+on:
+  push:
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'requirements*.txt'
+      - 'notebooks/**'
+      - '.github/**'
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,16 @@
 # notebooks
 .ipynb_checkpoints/
 _*.ipynb
+
+# local os
+.DS_Store
+
+# virtual env
+venv*/
+.venv*/
+
+# dot files
+.env*
+
+# testing
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 ### Option 1, local installation
 
+**Warning**: [ydata-profiling](https://docs.profiling.ydata.ai/latest/) install with python 3.13 [fails](https://github.com/munichpavel/ai-act-sound-data-science/actions/runs/15579643423/job/43871658179), so either use python 3.12 or lower, or [Option 2](#option-2-remotely-using-binder), below.
+
 First download the repository code in a local folder of your choice, either via `git clone`ing with
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ source .venv/bin/activate
 pip install -r requirements.txt -r requirements-dev.txt
 ```
 
-If using the python standard library's [venv](https://docs.python.org/3/library/venv.html), these steps would look something like
+If using the python standard library's [venv](https://docs.python.org/3/library/venv.html), these steps, run one by one, would look something like
 
 ```shell
 ➜  workshop-clones git:(main) ✗ git clone https://github.com/munichpavel/ai-act-sound-data-science.git
@@ -63,6 +63,14 @@ Collecting pytest
 ...
 ```
 
+To launch a jupyter notebook server and client, run from local repository root `jupyter notebook`:
+
+```shell
+(.venv) ➜  ai-act-sound-data-science git:(main) ✗ jupyter notebook
+[I 2025-06-11 09:09:55.011 ServerApp] jupyter_lsp | extension was successfully linked.
+[I 2025-06-11 09:09:55.015 ServerApp] jupyter_server_terminals | extension was successfully linked.
+...
+```
 
 ### Option 2, remotely using [binder](https://mybinder.readthedocs.io/en/latest/index.html#)
 

--- a/notebooks/extra-exercises.ipynb
+++ b/notebooks/extra-exercises.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e04f9ae9-55a2-471f-945f-c901aaeb6fad",
+   "metadata": {},
+   "source": [
+    "# Optional exercises and tasks\n",
+    "\n",
+    "in case you finish the scheduled ones early."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c9034bc",
+   "metadata": {},
+   "source": [
+    "## Exercise: Dependency management\n",
+    "\n",
+    "To get [mybinder.org](binder) to work for remote running of the workshop notebooks, I needed to put a `requirements.txt` file at the root of this project. \n",
+    "\n",
+    "1. What are some reasons for not pinning dependency versions in [../requirements.txt](requirements.txt)?\n",
+    "2. If I weren't forced to use a `requirements.txt` file, what are other options for our use case (with pros and cons)?\n",
+    "\n",
+    "### Resources\n",
+    "\n",
+    "* [https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/](https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/), and links therein."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5a7e152-9265-479d-a0b0-77aa2362c835",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,0 +1,69 @@
+'''
+Test that demo notebook cells execute without errors
+Using https://www.thedataincubator.com/blog/2016/06/09/testing-jupyter-notebooks/
+'''
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+import pytest
+
+import nbformat
+
+
+project_root = Path(__file__).parent.parent
+notebook_dir = project_root / 'notebooks'
+
+
+@pytest.mark.parametrize(
+    'notebook_path',
+    [
+        notebook_dir / 'eda-completed.ipynb',
+    ]
+)
+def test_ipynb(notebook_path, monkeypatch, tmpdir):
+
+    # Set up mock output directories
+    monkeypatch.setenv('SIMPSONS_DATA_DIR', str(tmpdir))
+    monkeypatch.setenv('SIMPSONS_DOC_ROOT', str(tmpdir))
+
+    errors = _notebook_run_errors(notebook_path)
+    assert not errors
+
+
+def _notebook_run_errors(path):
+    """
+    Execute a notebook via nbconvert and collect output.
+
+    Idiosyncratic implementation partially due to windows NamedTemporaryFile +
+    subprocess quirks. See
+
+    https://stackoverflow.com/questions/46497842/passing-namedtemporaryfile-to-a-subprocess-on-windows
+
+    and
+
+    https://github.com/bravoserver/bravo/issues/111#issuecomment-826990
+    """
+
+    file = tempfile.NamedTemporaryFile(suffix=".ipynb", delete=False)
+
+    args = [
+        "python", "-m", "nbconvert", "--to", "notebook", "--execute",
+        "--ExecutePreprocessor.timeout=60",
+        "--output", file.name, path
+    ]
+    subprocess.check_call(args)
+
+    file.seek(0)
+    nb = nbformat.read(file, nbformat.current_nbformat)
+
+    errors = [
+        output for cell in nb.cells if "outputs" in cell
+        for output in cell["outputs"] if output.output_type == "error"
+    ]
+
+    file.close()
+    os.unlink(file.name)
+
+    return errors

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -20,6 +20,7 @@ notebook_dir = project_root / 'notebooks'
     'notebook_path',
     [
         notebook_dir / 'eda-completed.ipynb',
+        notebook_dir / 'extra-exercises.ipynb',
     ]
 )
 def test_ipynb(notebook_path, monkeypatch, tmpdir):


### PR DESCRIPTION
mainly to check that all notebooks run (dependencies installed, data files can be loaded, ...) on multiple OSs and python versions.

Restriction discovered and documented: [ydata-profiling](https://github.com/ydataai/ydata-profiling) seems to need python <= 3.12 on all OSs tested. See e.g. [https://github.com/ydataai/ydata-profiling/pyproject.toml](https://github.com/ydataai/ydata-profiling/blob/develop/pyproject.toml)